### PR TITLE
BugFix: Update type PullRequest GetMergeCommit() to return commit Hash

### DIFF
--- a/bitbucket/bitbucket-accessors.go
+++ b/bitbucket/bitbucket-accessors.go
@@ -2487,10 +2487,10 @@ func (p *PullRequest) GetLinks() *PullRequestLinks {
 
 // GetMergeCommit returns the MergeCommit field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetMergeCommit() string {
-	if p == nil || p.MergeCommit == nil {
+	if p == nil || p.MergeCommit.Hash == nil {
 		return ""
 	}
-	return *p.MergeCommit
+	return *p.MergeCommit.Hash
 }
 
 // HasParticipants checks if PullRequest has any Participants.

--- a/bitbucket/bitbucket-accessors.go
+++ b/bitbucket/bitbucket-accessors.go
@@ -2485,12 +2485,12 @@ func (p *PullRequest) GetLinks() *PullRequestLinks {
 	return p.Links
 }
 
-// GetMergeCommit returns the MergeCommit field if it's non-nil, zero value otherwise.
-func (p *PullRequest) GetMergeCommit() string {
-	if p == nil || p.MergeCommit.Hash == nil {
-		return ""
+// GetMergeCommit returns the MergeCommit field.
+func (p *PullRequest) GetMergeCommit() *PullRequestMergeCommit {
+	if p == nil {
+		return nil
 	}
-	return *p.MergeCommit.Hash
+	return p.MergeCommit
 }
 
 // HasParticipants checks if PullRequest has any Participants.
@@ -2711,6 +2711,14 @@ func (p *PullRequestListOpts) HasState() bool {
 		return false
 	}
 	return true
+}
+
+// GetHash returns the Hash field if it's non-nil, zero value otherwise.
+func (p *PullRequestMergeCommit) GetHash() string {
+	if p == nil || p.Hash == nil {
+		return ""
+	}
+	return *p.Hash
 }
 
 // HasValues checks if PullRequests has any Values.

--- a/bitbucket/pull_requests.go
+++ b/bitbucket/pull_requests.go
@@ -17,29 +17,32 @@ type PullRequests struct {
 
 // PullRequest represents a Bitbucket pull request on a repository.
 type PullRequest struct {
-	Body              *PullRequestBody   `json:"rendered,omitempty"`
-	Type              *string            `json:"type,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	Links             *PullRequestLinks  `json:"links,omitempty"`
-	Title             *string            `json:"title,omitempty"`
-	CloseSourceBranch *bool              `json:"close_source_branch,omitempty"`
-	Reviewers         []*User            `json:"reviewers,omitempty"`
-	ID                *int64             `json:"id,omitempty"`
-	Destination       *PullRequestBranch `json:"destination,omitempty"`
-	CreatedOn         *time.Time         `json:"created_on,omitempty"`
-	Summary           *Content           `json:"summary,omitempty"`
-	Source            *PullRequestBranch `json:"source,omitempty"`
-	CommentCount      *int64             `json:"comment_count,omitempty"`
-	State             *string            `json:"state,omitempty"`
-	TaskCount         *int64             `json:"task_count,omitempty"`
-	Participants      []*Participant     `json:"participants,omitempty"`
-	Reason            *string            `json:"reason,omitempty"`
-	UpdatedOn         *string            `json:"updated_on,omitempty"`
-	Author            *User              `json:"author,omitempty"`
-	MergeCommit       struct {
-		Hash *string `json:"hash,omitempty"`
-	} `json:"merge_commit,omitempty"`
-	ClosedBy *User `json:"closed_by,omitempty"`
+	Body              *PullRequestBody        `json:"rendered,omitempty"`
+	Type              *string                 `json:"type,omitempty"`
+	Description       *string                 `json:"description,omitempty"`
+	Links             *PullRequestLinks       `json:"links,omitempty"`
+	Title             *string                 `json:"title,omitempty"`
+	CloseSourceBranch *bool                   `json:"close_source_branch,omitempty"`
+	Reviewers         []*User                 `json:"reviewers,omitempty"`
+	ID                *int64                  `json:"id,omitempty"`
+	Destination       *PullRequestBranch      `json:"destination,omitempty"`
+	CreatedOn         *time.Time              `json:"created_on,omitempty"`
+	Summary           *Content                `json:"summary,omitempty"`
+	Source            *PullRequestBranch      `json:"source,omitempty"`
+	CommentCount      *int64                  `json:"comment_count,omitempty"`
+	State             *string                 `json:"state,omitempty"`
+	TaskCount         *int64                  `json:"task_count,omitempty"`
+	Participants      []*Participant          `json:"participants,omitempty"`
+	Reason            *string                 `json:"reason,omitempty"`
+	UpdatedOn         *string                 `json:"updated_on,omitempty"`
+	Author            *User                   `json:"author,omitempty"`
+	MergeCommit       *PullRequestMergeCommit `json:"merge_commit,omitempty"`
+	ClosedBy          *User                   `json:"closed_by,omitempty"`
+}
+
+// PullRequestMergeCommit represents the "merge_commit" object in a Bitbucket pull request.
+type PullRequestMergeCommit struct {
+	Hash *string `json:"hash,omitempty"`
 }
 
 // PullRequestLinks represents the "links" object in a Bitbucket pull request.

--- a/bitbucket/pull_requests.go
+++ b/bitbucket/pull_requests.go
@@ -36,8 +36,10 @@ type PullRequest struct {
 	Reason            *string            `json:"reason,omitempty"`
 	UpdatedOn         *string            `json:"updated_on,omitempty"`
 	Author            *User              `json:"author,omitempty"`
-	MergeCommit       *string            `json:"merge_commit,omitempty"`
-	ClosedBy          *User              `json:"closed_by,omitempty"`
+	MergeCommit       struct {
+		Hash *string `json:"hash,omitempty"`
+	} `json:"merge_commit,omitempty"`
+	ClosedBy *User `json:"closed_by,omitempty"`
 }
 
 // PullRequestLinks represents the "links" object in a Bitbucket pull request.


### PR DESCRIPTION
[The API has probably changed](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests/%7Bpull_request_id%7D/merge) in the meantime and was throwing an unmarshal error for merge_commit for the returned object of MergePR.

Updating the code to unmarshal the hash correctly again.
