### PR TITLE
Fixed repositories list deserializing the value to the issue type instead of repository type

### DIFF
--- a/bitbucket/repositories.go
+++ b/bitbucket/repositories.go
@@ -2,8 +2,9 @@ package bitbucket
 
 import (
 	"fmt"
-	"github.com/davidji99/simpleresty"
 	"time"
+
+	"github.com/davidji99/simpleresty"
 )
 
 // RepositoriesService handles communication with the repository related methods
@@ -16,7 +17,7 @@ type RepositoriesService service
 type Repositories struct {
 	PaginationInfo
 
-	Values []*Issue `json:"values,omitempty"`
+	Values []*Repository `json:"values,omitempty"`
 }
 
 // Repository represents a Bitbucket repository.


### PR DESCRIPTION
I'm not really sure why, probably just a mistake but the Repositories struct contained an array of issues instead of an array of repositories